### PR TITLE
Fix RecursionError for filaments with many segments

### DIFF
--- a/VesselExpress/modules/filament.py
+++ b/VesselExpress/modules/filament.py
@@ -281,7 +281,7 @@ class Filament:
         """
         self.segmentsDict[segment[0], segment[len(segment) - 1]] = segment
         if self.smallRAMmode == 1:
-            radius = ms.getRadius(da.from_zarr('tmp_zarr' + os.sep + self.fileName + '_radiusMatrix.zarr'), segment)
+            radius = ms.getRadius(da.from_zarr('tmp_zarr' + os.sep + self.fileName + '_radiusMatrix.zarr'), segment, 1)
         else:
             radius = ms.getRadius(self.skelRadii, segment)
 
@@ -302,7 +302,7 @@ class Filament:
         if interpolate:
             if self.smallRAMmode == 1:
                 volume = ms.getVolume(da.from_zarr('tmp_zarr' + os.sep + self.fileName + '_radiusMatrix.zarr'),
-                                      coords, self.pixelDims)
+                                      coords, self.pixelDims).compute()
             else:
                 #volume = ms.getVolume(self.skelRadii, coords, self.pixelDims)
                 volume = ms.getVolumeCylinder(radius, segLength)

--- a/VesselExpress/modules/measurements.py
+++ b/VesselExpress/modules/measurements.py
@@ -30,10 +30,17 @@ def getLength(path, dimensions):
     return length
 
 
-def getRadius(distTrans, segment):
+def getRadius(distTrans, segment, smallRAMmode=0):
     sumRadii = 0
-    for skelPt in segment:
-        sumRadii += distTrans[skelPt]
+    if not smallRAMmode:
+        for skelPt in segment:
+            sumRadii += distTrans[skelPt]
+    else:
+        for i, skelPt in enumerate(segment):
+            sumRadii += distTrans[skelPt]
+            if i % 100 == 99:
+                sumRadii = sumRadii.compute()
+        sumRadii = sumRadii.compute()
     return sumRadii / len(segment)
 
 


### PR DESCRIPTION
The .compute() function converts a dask array back to a "normal" python array. If many operations have been performed on dask arrays before calling compute(), this can result in a RecursionError. The compute() function internally converts all steps recursively which can lead to a too high recursion depth for python. This happened for me in the getRadius() function where the sum over the segments is performed on dask arrays. Calling compute() every 100 iterations solved the issue for me. 
Hope this helps.